### PR TITLE
Fix checklist retry filter to match API status value

### DIFF
--- a/server/routes/api/content.ts
+++ b/server/routes/api/content.ts
@@ -1028,7 +1028,7 @@ export function registerContentRoutes(app: Express) {
         if (itemsToEnhance.length === 0 && currentChecklistResults.passedItems < minimumTotalPoints) {
           const naItems = Object.values(currentChecklistResults.categories)
             .flat()
-            .filter((item: any) => item.status === 'notApplicable')
+            .filter((item: any) => item.status === 'not_applicable')
             .map((item: any) => ({ id: item.id, category: item.category, description: item.description, status: item.status }));
           
           // Take enough N/A items to reach our target


### PR DESCRIPTION
## Summary
- update the checklist retry loop to look for the not_applicable status returned by the checklist service

## Testing
- npm run check *(fails: existing type errors in unrelated client files)*

------
https://chatgpt.com/codex/tasks/task_e_68cc116c3068832982e48531e73cfc38