### PR TITLE
Use Readable.fromWeb when streaming URL responses

### DIFF
--- a/server/routes/api/content.ts
+++ b/server/routes/api/content.ts
@@ -292,7 +292,7 @@ async function fetchContentFromURL(url: string): Promise<string> {
     let html: string;
     if (response.body) {
       // Use streaming for better memory efficiency
-      const stream = Readable.from(response.body as any);
+      const stream = Readable.fromWeb(response.body as any);
       html = await readStreamWithLimit(stream, MAX_CONTENT_SIZE);
     } else {
       // Fallback to text() method


### PR DESCRIPTION
## Summary
- replace use of `Readable.from` with `Readable.fromWeb` when converting fetch response bodies
- continue to fall back to `response.text()` when no stream is available

## Testing
- `npm run check` *(fails: existing TypeScript errors in client components unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68cc1185ce4c8329a28738d07439f37f