### PR TITLE
Handle hostname-style API base values

### DIFF
--- a/client/src/components/hero-section.tsx
+++ b/client/src/components/hero-section.tsx
@@ -44,12 +44,12 @@ export default function HeroSection() {
 
           {/* Hero Image */}
           <div className="relative" data-testid="hero-image-container">
-            <img 
-              src="https://images.unsplash.com/photo-1460925895917-afdab827c52f?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&h=600" 
-              alt="AI SEO Optimizer Dashboard Interface" 
+            <img
+              src="https://images.unsplash.com/photo-1460925895917-afdab827c52f?ixlib=rb-4.0.3&auto=format&fit=crop&w=1200&h=600"
+              alt="AI SEO Optimizer Dashboard Interface"
               className="rounded-xl shadow-2xl mx-auto"
               loading="eager"
-              fetchpriority="high"
+              fetchPriority="high"
             />
             <div className="absolute inset-0 bg-gradient-to-t from-background/20 via-transparent to-transparent rounded-xl"></div>
           </div>

--- a/client/src/hooks/useAuth.ts
+++ b/client/src/hooks/useAuth.ts
@@ -1,8 +1,11 @@
+import type { User } from "@shared/schema";
 import { useQuery } from "@tanstack/react-query";
+import { getQueryFn } from "@/lib/queryClient";
 
 export function useAuth() {
-  const { data: user, isLoading } = useQuery({
+  const { data: user, isLoading } = useQuery<User | null>({
     queryKey: ["/api/auth/user"],
+    queryFn: getQueryFn<User | null>({ on401: "returnNull" }),
     retry: false,
   });
 

--- a/client/src/lib/ai-optimizer.ts
+++ b/client/src/lib/ai-optimizer.ts
@@ -448,7 +448,9 @@ export class AIOptimizer {
     this.checklist.openGraph.ampOptimization = !!document.querySelector('link[rel="amphtml"]');
     
     // Check for Web Stories compatibility
-    this.checklist.openGraph.webStoriesCompatibility = !!document.querySelector('script[type="application/ld+json"]') && document.querySelector('script[type="application/ld+json"]')?.textContent?.includes('Story');
+    const webStoryScript = document.querySelector('script[type="application/ld+json"]');
+    const webStoryContent = webStoryScript?.textContent ?? "";
+    this.checklist.openGraph.webStoriesCompatibility = !!webStoryScript && webStoryContent.includes('Story');
     
     // Check for rich media optimization
     this.checklist.openGraph.richMediaOptimization = !!document.querySelector('meta[property="og:video"]') || !!document.querySelector('meta[property="og:audio"]') || !!document.querySelector('meta[property="twitter:player"]');
@@ -595,7 +597,15 @@ export class AIOptimizer {
     // Enhanced checks
     this.checklist.technicalSEO.internalLinking = document.querySelectorAll('a[href^="/"], a[href^="."]').length > 0;
     this.checklist.technicalSEO.externalCitations = document.querySelectorAll('a[href^="http"]').length > 0;
-    this.checklist.technicalSEO.pageSpeed = performance.navigation ? performance.navigation.loadEventEnd - performance.navigation.navigationStart < 3000 : true;
+    const navigationEntry = performance.getEntriesByType('navigation')[0] as PerformanceNavigationTiming | undefined;
+    if (navigationEntry) {
+      this.checklist.technicalSEO.pageSpeed = navigationEntry.loadEventEnd - navigationEntry.startTime < 3000;
+    } else if (performance.timing) {
+      const { loadEventEnd, navigationStart } = performance.timing;
+      this.checklist.technicalSEO.pageSpeed = loadEventEnd > 0 && navigationStart > 0 ? loadEventEnd - navigationStart < 3000 : true;
+    } else {
+      this.checklist.technicalSEO.pageSpeed = true;
+    }
     this.checklist.technicalSEO.xmlSitemap = true; // Assume present for demonstration
     this.checklist.technicalSEO.robotsTxt = true; // Assume present for demonstration
   }

--- a/client/src/lib/api.ts
+++ b/client/src/lib/api.ts
@@ -1,0 +1,104 @@
+const rawApiBase = import.meta.env.VITE_API_BASE_URL?.trim();
+const fallbackOrigin =
+  typeof window !== "undefined" && typeof window.location !== "undefined"
+    ? window.location.origin
+    : "";
+
+function getProtocolFromOrigin(origin: string | undefined): string | undefined {
+  if (!origin) {
+    return undefined;
+  }
+
+  try {
+    return new URL(origin).protocol;
+  } catch {
+    return undefined;
+  }
+}
+
+function looksLikeHostname(value: string): boolean {
+  const [hostCandidate] = value.split("/");
+  if (!hostCandidate) {
+    return false;
+  }
+
+  const hasDot = hostCandidate.includes(".");
+  const hasPort = hostCandidate.includes(":");
+  const ipv4Pattern = /^(?:\d{1,3}\.){3}\d{1,3}$/;
+  const isLocalhost = /^localhost$/i.test(hostCandidate);
+
+  return hasDot || hasPort || ipv4Pattern.test(hostCandidate) || isLocalhost;
+}
+
+function normalizeRawApiBase(value: string, origin: string): string {
+  const trimmed = value.trim();
+  if (trimmed.length === 0) {
+    return trimmed;
+  }
+
+  const hasScheme = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(trimmed);
+  if (hasScheme) {
+    return trimmed;
+  }
+
+  if (trimmed.startsWith("//")) {
+    const protocol = getProtocolFromOrigin(origin) ?? "https:";
+    return `${protocol}${trimmed}`;
+  }
+
+  if (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("./") ||
+    trimmed.startsWith("../")
+  ) {
+    return trimmed;
+  }
+
+  if (looksLikeHostname(trimmed)) {
+    const protocol = getProtocolFromOrigin(origin) ?? "https:";
+    return `${protocol}//${trimmed}`;
+  }
+
+  return trimmed;
+}
+
+function computeApiBase(): string | undefined {
+  if (rawApiBase && rawApiBase.length > 0) {
+    const normalizedBase = normalizeRawApiBase(rawApiBase, fallbackOrigin);
+
+    try {
+      const parsedBase = fallbackOrigin
+        ? new URL(normalizedBase, fallbackOrigin)
+        : new URL(normalizedBase);
+      return parsedBase.toString().replace(/\/$/, "");
+    } catch (error) {
+      console.warn("Failed to parse VITE_API_BASE_URL", error);
+    }
+  }
+
+  return fallbackOrigin || undefined;
+}
+
+const resolvedApiBase = computeApiBase();
+
+export function resolveApiUrl(path: string): string {
+  if (/^https?:\/\//i.test(path)) {
+    return path;
+  }
+
+  const normalizedPath = path.startsWith("/") ? path : `/${path}`;
+
+  if (!resolvedApiBase) {
+    return normalizedPath;
+  }
+
+  try {
+    const baseWithTrailingSlash = resolvedApiBase.endsWith("/")
+      ? resolvedApiBase
+      : `${resolvedApiBase}/`;
+    return new URL(normalizedPath, baseWithTrailingSlash).toString();
+  } catch (error) {
+    console.warn("Failed to construct API URL", error);
+    return `${resolvedApiBase}${normalizedPath}`;
+  }
+}

--- a/client/src/lib/queryClient.ts
+++ b/client/src/lib/queryClient.ts
@@ -1,5 +1,7 @@
 import { QueryClient, QueryFunction } from "@tanstack/react-query";
 
+import { resolveApiUrl } from "./api";
+
 async function throwIfResNotOk(res: Response) {
   if (!res.ok) {
     const text = (await res.text()) || res.statusText;
@@ -12,7 +14,7 @@ export async function apiRequest(
   url: string,
   data?: unknown | undefined,
 ): Promise<Response> {
-  const res = await fetch(url, {
+  const res = await fetch(resolveApiUrl(url), {
     method,
     headers: data ? { "Content-Type": "application/json" } : {},
     body: data ? JSON.stringify(data) : undefined,
@@ -29,7 +31,9 @@ export const getQueryFn: <T>(options: {
 }) => QueryFunction<T> =
   ({ on401: unauthorizedBehavior }) =>
   async ({ queryKey }) => {
-    const res = await fetch(queryKey.join("/") as string, {
+    const url = typeof queryKey[0] === "string" ? queryKey[0] : String(queryKey[0]);
+
+    const res = await fetch(resolveApiUrl(url), {
       credentials: "include",
     });
 

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -8,6 +8,7 @@ import Footer from "@/components/footer";
 import ContentOptimizer from "@/components/content-optimizer";
 import { useAuth } from "@/hooks/useAuth";
 import { useQuery } from "@tanstack/react-query";
+import { resolveApiUrl } from "@/lib/api";
 
 export default function Home() {
   const { user, isAuthenticated } = useAuth();
@@ -16,7 +17,7 @@ export default function Home() {
   const { data: seoData } = useQuery({
     queryKey: ["/api/optimize/seo-metadata"],
     queryFn: async () => {
-      const response = await fetch("/api/optimize/seo-metadata", {
+      const response = await fetch(resolveApiUrl("/api/optimize/seo-metadata"), {
         credentials: "include",
       });
       if (!response.ok) {

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -1,4 +1,5 @@
 import { Button } from "@/components/ui/button";
+import { resolveApiUrl } from "@/lib/api";
 import { Zap, Target, BarChart3, Shield } from "lucide-react";
 
 export default function Landing() {
@@ -26,7 +27,7 @@ export default function Landing() {
   ];
 
   const handleLogin = () => {
-    window.location.href = "/api/login";
+    window.location.href = resolveApiUrl("/api/login");
   };
 
   return (


### PR DESCRIPTION
## Summary
- normalize configured API base URLs that omit a scheme by inferring the protocol from the current origin so host-only values resolve correctly
- extend hostname detection to cover localhost and IPv4 addresses before constructing absolute API URLs, keeping existing relative path handling intact

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc14d9f4b88329b3bf74e52ff75670