### PR TITLE
Update CI workflow to target default branch

### DIFF
--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -1,0 +1,31 @@
+name: Node CI
+
+on:
+  push:
+    branches:
+      - $default-branch
+  pull_request:
+    branches:
+      - $default-branch
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Use Node.js 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run type checks
+        run: npm run check --if-present
+
+      - name: Build application
+        run: npm run build --if-present

--- a/README.md
+++ b/README.md
@@ -1,0 +1,7 @@
+# AI Content King
+
+AI Content King provides tools for generating and optimizing SEO friendly content across both the client and server packages in this monorepo.
+
+## Continuous Integration
+
+The **Node CI** workflow in `.github/workflows/node-ci.yml` runs automatically for pushes and pull requests that target the repository's default branch (exposed in GitHub as `$default-branch`, typically `main`). The workflow installs dependencies with `npm ci`, runs available type checks, and builds the application to ensure changes are production ready before merging.


### PR DESCRIPTION
## Summary
- update the Node CI workflow to trigger on the repository default branch using the `$default-branch` keyword
- document the continuous integration workflow in the README, noting it now targets the default branch and outlines the checks it runs

## Testing
- npm run check

------
https://chatgpt.com/codex/tasks/task_e_68cc42c091688329860e66e8be2b71c8