### PR TITLE
feat(auth): add local auth mode and make OIDC optional

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,18 @@
+# Copy this file to .env and fill in the values for your environment.
+# SESSION_SECRET is required in all modes.
+SESSION_SECRET=
+
+# AUTH_MODE defaults to "local" when OIDC settings are missing.
+AUTH_MODE=local
+REPLIT_DOMAINS=*.repl.co,*.replit.app,*.github.dev
+
+# OIDC (required only for AUTH_MODE=oidc):
+OIDC_ISSUER=
+OIDC_CLIENT_ID=
+OIDC_CLIENT_SECRET=
+OIDC_REDIRECT_URI=
+
+# E2E/local testing:
+TEST_USER_EMAIL=test@example.com
+TEST_USER_PASSWORD=password
+TEST_SEED_TOKEN=dev-seed-token

--- a/.github/workflows/node-ci.yml
+++ b/.github/workflows/node-ci.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      SESSION_SECRET: ci-session-secret
+      AUTH_MODE: local
     steps:
       - name: Check out code
         uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -1,14 +1,30 @@
 AI Content King combines an Express backend and a React frontend to help teams generate and optimize long-form content for AI-forward search engines.
 
+## Getting Started
+
+1. Copy `.env.sample` to `.env` and set at least `SESSION_SECRET`.
+   - `AUTH_MODE` defaults to `local` whenever the OIDC variables are missing.
+   - For local and CI usage you can keep the generated test credentials or override `TEST_USER_EMAIL` and `TEST_USER_PASSWORD`.
+2. Install dependencies with `npm install`.
+3. Start the development server with `npm run dev`.
+   - The server binds to `0.0.0.0:${PORT}` (defaults to `5000`).
+   - In GitHub Codespaces, run the same command and open the forwarded port in the browser.
+
+### Authentication modes
+
+- **Local mode** (default): does not require OIDC credentials. A lightweight Passport local strategy authenticates against the test user defined by `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`. The `/login`, `/logout`, and `/me` helpers (also available under `/api`) let you exercise sessions without external providers.
+- **OIDC mode**: set `AUTH_MODE=oidc` and provide `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, and `OIDC_REDIRECT_URI`. Existing Replit OIDC flows continue to work with these variables.
+
+The guarded route `/__test__/seed-and-login` seeds and signs in the local test user, but it is only available when `NODE_ENV=test` **and** `TEST_SEED_TOKEN` are configured. Never enable the helper in production.
+
 ## Continuous Integration
 
-The **Node CI** workflow in `.github/workflows/node-ci.yml` runs automatically for pushes and pull requests to the default branch (usually `main`). It installs dependencies with `npm ci` (falls back to `npm install` if needed), then conditionally runs `npm run build` and `npm test --if-present`. When present, build artifacts in `dist/` and coverage in `coverage/` are uploaded to the run.
+The **Node CI** workflow in `.github/workflows/node-ci.yml` runs automatically for pushes and pull requests to the default branch (usually `main`). It installs dependencies with `npm ci` (falls back to `npm install` if needed), then conditionally runs `npm run build` and `npm test --if-present`. When present, build artifacts in `dist/` and coverage in `coverage/` are uploaded to the run. CI enforces `AUTH_MODE=local` so no external secrets are required.
 
 ## Testing
 
 Playwright E2E coverage signs in as a seeded test user, drives the content generator/optimizer, and asserts on the resulting output.
 
-**Run locally**
 1. Copy `.env.sample` → `.env` and provide:
    - `SESSION_SECRET` (for Express sessions)
    - `TEST_USER_EMAIL`, `TEST_USER_PASSWORD` (test user credentials)

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,6 +47,7 @@
         "cmdk": "^1.1.1",
         "connect-pg-simple": "^10.0.0",
         "date-fns": "^3.6.0",
+        "dotenv": "file:vendor/dotenv",
         "drizzle-orm": "^0.39.1",
         "drizzle-zod": "^0.7.0",
         "embla-carousel-react": "^8.6.0",
@@ -4531,6 +4532,10 @@
         "url": "https://github.com/fb55/domutils?sponsor=1"
       }
     },
+    "node_modules/dotenv": {
+      "resolved": "vendor/dotenv",
+      "link": true
+    },
     "node_modules/drizzle-kit": {
       "version": "0.31.4",
       "resolved": "https://registry.npmjs.org/drizzle-kit/-/drizzle-kit-0.31.4.tgz",
@@ -8885,6 +8890,9 @@
       "peerDependencies": {
         "zod": "^3.18.0"
       }
+    },
+    "vendor/dotenv": {
+      "version": "16.4.5"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "date-fns": "^3.6.0",
     "drizzle-orm": "^0.39.1",
     "drizzle-zod": "^0.7.0",
+    "dotenv": "file:vendor/dotenv",
     "embla-carousel-react": "^8.6.0",
     "express": "^4.21.2",
     "express-session": "^1.18.1",

--- a/server/config.ts
+++ b/server/config.ts
@@ -1,0 +1,108 @@
+import "dotenv/config";
+
+export type AuthMode = "oidc" | "local";
+
+export interface AppConfig {
+  NODE_ENV: string;
+  PORT: number;
+  AUTH_MODE: AuthMode;
+  SESSION_SECRET: string;
+  REPLIT_DOMAINS: string;
+  OIDC_ISSUER?: string;
+  OIDC_CLIENT_ID?: string;
+  OIDC_CLIENT_SECRET?: string;
+  OIDC_REDIRECT_URI?: string;
+  TEST_USER_EMAIL?: string;
+  TEST_USER_PASSWORD?: string;
+  TEST_SEED_TOKEN?: string;
+}
+
+const NODE_ENV = process.env.NODE_ENV ?? "development";
+const PORT = Number.parseInt(process.env.PORT ?? "5000", 10);
+const SESSION_SECRET = process.env.SESSION_SECRET;
+
+if (!SESSION_SECRET) {
+  throw new Error(
+    "SESSION_SECRET env var is required. Set it in your .env file (see .env.sample).",
+  );
+}
+
+const OIDC_ISSUER =
+  process.env.OIDC_ISSUER ?? process.env.ISSUER_URL ?? undefined;
+const OIDC_CLIENT_ID =
+  process.env.OIDC_CLIENT_ID ?? process.env.REPL_ID ?? undefined;
+const OIDC_CLIENT_SECRET =
+  process.env.OIDC_CLIENT_SECRET ?? process.env.REPLIT_CLIENT_SECRET ?? undefined;
+const OIDC_REDIRECT_URI =
+  process.env.OIDC_REDIRECT_URI ?? process.env.REPLIT_REDIRECT_URI ?? undefined;
+
+const rawAuthMode = process.env.AUTH_MODE?.toLowerCase();
+const explicitAuthMode =
+  rawAuthMode === "oidc" || rawAuthMode === "local"
+    ? (rawAuthMode as AuthMode)
+    : undefined;
+
+let AUTH_MODE: AuthMode;
+if (explicitAuthMode) {
+  AUTH_MODE = explicitAuthMode;
+} else if (OIDC_ISSUER && OIDC_CLIENT_ID && OIDC_CLIENT_SECRET && OIDC_REDIRECT_URI) {
+  AUTH_MODE = "oidc";
+} else {
+  AUTH_MODE = "local";
+}
+
+if (AUTH_MODE === "oidc") {
+  const missing = [
+    ["OIDC_ISSUER", OIDC_ISSUER],
+    ["OIDC_CLIENT_ID", OIDC_CLIENT_ID],
+    ["OIDC_CLIENT_SECRET", OIDC_CLIENT_SECRET],
+    ["OIDC_REDIRECT_URI", OIDC_REDIRECT_URI],
+  ]
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required env vars for AUTH_MODE=oidc: ${missing.join(", ")}`,
+    );
+  }
+}
+
+const REPLIT_DOMAINS =
+  process.env.REPLIT_DOMAINS ?? "*.repl.co,*.replit.app,*.github.dev";
+
+const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL;
+const TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD;
+const TEST_SEED_TOKEN = process.env.TEST_SEED_TOKEN;
+
+if (AUTH_MODE === "local" && NODE_ENV === "production") {
+  const missing = [
+    ["TEST_USER_EMAIL", TEST_USER_EMAIL],
+    ["TEST_USER_PASSWORD", TEST_USER_PASSWORD],
+  ]
+    .filter(([, value]) => !value)
+    .map(([key]) => key);
+
+  if (missing.length > 0) {
+    throw new Error(
+      `Missing required env vars for production local auth: ${missing.join(", ")}`,
+    );
+  }
+}
+
+export const config: AppConfig = {
+  NODE_ENV,
+  PORT,
+  AUTH_MODE,
+  SESSION_SECRET,
+  REPLIT_DOMAINS,
+  OIDC_ISSUER,
+  OIDC_CLIENT_ID,
+  OIDC_CLIENT_SECRET,
+  OIDC_REDIRECT_URI,
+  TEST_USER_EMAIL,
+  TEST_USER_PASSWORD,
+  TEST_SEED_TOKEN,
+};
+
+export default config;

--- a/server/index.ts
+++ b/server/index.ts
@@ -1,8 +1,10 @@
 import express, { type Request, Response, NextFunction } from "express";
+import config from "./config";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
 const app = express();
+app.set("env", config.NODE_ENV);
 app.use(express.json());
 app.use(express.urlencoded({ extended: false }));
 
@@ -37,7 +39,7 @@ app.use((req, res, next) => {
 });
 
 (async () => {
-  const server = await registerRoutes(app);
+  const server = await registerRoutes(app, config);
 
   app.use((err: any, _req: Request, res: Response, _next: NextFunction) => {
     const status = err.status || err.statusCode || 500;
@@ -60,12 +62,14 @@ app.use((req, res, next) => {
   // Other ports are firewalled. Default to 5000 if not specified.
   // this serves both the API and the client.
   // It is the only port that is not firewalled.
-  const port = parseInt(process.env.PORT || '5000', 10);
-  server.listen({
-    port,
-    host: "0.0.0.0",
-    reusePort: true,
-  }, () => {
-    log(`serving on port ${port}`);
-  });
+  server.listen(
+    {
+      port: config.PORT,
+      host: "0.0.0.0",
+      reusePort: true,
+    },
+    () => {
+      log(`serving on port ${config.PORT}`);
+    },
+  );
 })();

--- a/server/replitAuth.ts
+++ b/server/replitAuth.ts
@@ -1,62 +1,88 @@
-import * as client from "openid-client";
-import { Strategy, type VerifyFunction } from "openid-client/passport";
-
-import passport from "passport";
+import { Router, type Express, type RequestHandler } from "express";
 import session from "express-session";
-import type { Express, RequestHandler } from "express";
+import passport from "passport";
+import { Strategy as LocalStrategy } from "passport-local";
+import * as client from "openid-client";
+import { Strategy as OidcStrategy, type VerifyFunction } from "openid-client/passport";
 import memoize from "memoizee";
 import connectPg from "connect-pg-simple";
+import memorystore from "memorystore";
+
+import type { AppConfig, AuthMode } from "./config";
 import { storage } from "./storage";
 
-if (!process.env.REPLIT_DOMAINS) {
-  throw new Error("Environment variable REPLIT_DOMAINS not provided");
-}
+type OidcTokenResponse = client.TokenEndpointResponse &
+  client.TokenEndpointResponseHelpers;
 
-const getOidcConfig = memoize(
-  async () => {
-    return await client.discovery(
-      new URL(process.env.ISSUER_URL ?? "https://replit.com/oidc"),
-      process.env.REPL_ID!
-    );
-  },
-  { maxAge: 3600 * 1000 }
+type LocalAuthUser = {
+  id: string;
+  claims: {
+    sub: string;
+    email?: string;
+    first_name?: string;
+    last_name?: string;
+  };
+};
+
+const getOidcDiscovery = memoize(
+  async (issuer: string, clientId: string) =>
+    client.discovery(new URL(issuer), clientId),
+  { maxAge: 60 * 60 * 1000, normalizer: (args: [string, string]) => args.join("::") },
 );
 
-export function getSession() {
+let currentMode: AuthMode = "local";
+let currentConfig: AppConfig | null = null;
+
+function requireConfig(): AppConfig {
+  if (!currentConfig) {
+    throw new Error("Authentication has not been initialized yet");
+  }
+
+  return currentConfig;
+}
+
+function getSession(config: AppConfig) {
   const sessionTtl = 7 * 24 * 60 * 60 * 1000; // 1 week
-  const pgStore = connectPg(session);
-  const sessionStore = new pgStore({
-    conString: process.env.DATABASE_URL,
-    createTableIfMissing: false,
-    ttl: sessionTtl,
-    tableName: "sessions",
-  });
+  const databaseUrl = process.env.DATABASE_URL;
+
+  let sessionStore: session.Store;
+
+  if (databaseUrl) {
+    const PgStore = connectPg(session);
+    sessionStore = new PgStore({
+      conString: databaseUrl,
+      createTableIfMissing: false,
+      ttl: sessionTtl,
+      tableName: "sessions",
+    });
+  } else {
+    const MemoryStore = memorystore(session);
+    sessionStore = new MemoryStore({
+      checkPeriod: sessionTtl,
+    });
+  }
+
   return session({
-    secret: process.env.SESSION_SECRET!,
+    secret: config.SESSION_SECRET,
     store: sessionStore,
     resave: false,
     saveUninitialized: false,
     cookie: {
       httpOnly: true,
-      secure: true,
+      secure: config.NODE_ENV === "production",
       maxAge: sessionTtl,
     },
   });
 }
 
-function updateUserSession(
-  user: any,
-  tokens: client.TokenEndpointResponse & client.TokenEndpointResponseHelpers
-) {
+function updateUserSession(user: any, tokens: OidcTokenResponse) {
   user.claims = tokens.claims();
   user.access_token = tokens.access_token;
   user.refresh_token = tokens.refresh_token;
   user.expires_at = user.claims?.exp;
 }
 
-async function upsertUser(
-  claims: any,
-) {
+async function upsertUser(claims: any) {
   await storage.upsertUser({
     id: claims["sub"],
     email: claims["email"],
@@ -66,40 +92,40 @@ async function upsertUser(
   });
 }
 
-export async function setupAuth(app: Express) {
-  app.set("trust proxy", 1);
-  app.use(getSession());
-  app.use(passport.initialize());
-  app.use(passport.session());
+async function setupOidc(app: Express, config: AppConfig) {
+  if (!config.OIDC_ISSUER || !config.OIDC_CLIENT_ID || !config.OIDC_REDIRECT_URI) {
+    throw new Error("Missing OIDC configuration for AUTH_MODE=oidc");
+  }
 
-  const config = await getOidcConfig();
+  const oidcConfig = await getOidcDiscovery(
+    config.OIDC_ISSUER,
+    config.OIDC_CLIENT_ID,
+  );
 
   const verify: VerifyFunction = async (
-    tokens: client.TokenEndpointResponse & client.TokenEndpointResponseHelpers,
-    verified: passport.AuthenticateCallback
+    tokens: OidcTokenResponse,
+    verified: passport.AuthenticateCallback,
   ) => {
-    const user = {};
+    const user: any = {};
     updateUserSession(user, tokens);
     await upsertUser(tokens.claims());
     verified(null, user);
   };
 
-  for (const domain of process.env
-    .REPLIT_DOMAINS!.split(",")) {
-    const strategy = new Strategy(
+  const domains = config.REPLIT_DOMAINS.split(",").map((domain) => domain.trim()).filter(Boolean);
+
+  for (const domain of domains) {
+    const strategy = new OidcStrategy(
       {
         name: `replitauth:${domain}`,
-        config,
+        config: oidcConfig,
         scope: "openid email profile offline_access",
-        callbackURL: `https://${domain}/api/callback`,
+        callbackURL: config.OIDC_REDIRECT_URI ?? `https://${domain}/api/callback`,
       },
       verify,
     );
     passport.use(strategy);
   }
-
-  passport.serializeUser((user: Express.User, cb) => cb(null, user));
-  passport.deserializeUser((user: Express.User, cb) => cb(null, user));
 
   app.get("/api/login", (req, res, next) => {
     passport.authenticate(`replitauth:${req.hostname}`, {
@@ -117,26 +143,267 @@ export async function setupAuth(app: Express) {
 
   app.get("/api/logout", (req, res) => {
     req.logout(() => {
+      const redirectUri = config.OIDC_REDIRECT_URI ?? `${req.protocol}://${req.hostname}`;
       res.redirect(
-        client.buildEndSessionUrl(config, {
-          client_id: process.env.REPL_ID!,
-          post_logout_redirect_uri: `${req.protocol}://${req.hostname}`,
-        }).href
+        client
+          .buildEndSessionUrl(oidcConfig, {
+            client_id: config.OIDC_CLIENT_ID!,
+            post_logout_redirect_uri: redirectUri,
+          })
+          .href,
       );
     });
   });
 }
 
+function setupLocal(app: Express, config: AppConfig) {
+  const defaultEmail =
+    config.TEST_USER_EMAIL ?? (config.NODE_ENV !== "production" ? "test@example.com" : undefined);
+  const defaultPassword =
+    config.TEST_USER_PASSWORD ?? (config.NODE_ENV !== "production" ? "password" : undefined);
+
+  if (!defaultEmail || !defaultPassword) {
+    throw new Error(
+      "Local auth mode requires TEST_USER_EMAIL and TEST_USER_PASSWORD (or defaults outside production)",
+    );
+  }
+
+  const localUserId = `local-${defaultEmail}`;
+  const localUser: LocalAuthUser = {
+    id: localUserId,
+    claims: {
+      sub: localUserId,
+      email: defaultEmail,
+      first_name: "Local",
+      last_name: "User",
+    },
+  };
+
+  passport.use(
+    new LocalStrategy(
+      { usernameField: "email", passwordField: "password" },
+      async (email, password, done) => {
+        if (email !== defaultEmail || password !== defaultPassword) {
+          return done(null, false, { message: "Invalid email or password" });
+        }
+
+        await storage.upsertUser({
+          id: localUserId,
+          email: defaultEmail,
+          firstName: localUser.claims.first_name,
+          lastName: localUser.claims.last_name,
+        });
+
+        return done(null, { ...localUser });
+      },
+    ),
+  );
+
+  const router = Router();
+
+  router.post("/login", (req, res, next) => {
+    passport.authenticate(
+      "local",
+      (
+        err: Error | null,
+        user: LocalAuthUser | false,
+        info?: { message?: string },
+      ) => {
+        if (err) {
+          next(err);
+          return;
+        }
+
+        if (!user) {
+          res.status(401).json({ message: info?.message ?? "Invalid credentials" });
+          return;
+        }
+
+        req.login(user, (loginError) => {
+          if (loginError) {
+            next(loginError);
+            return;
+          }
+
+          const wantsHtml = req.accepts(["html", "json"]) === "html";
+
+          if (wantsHtml) {
+            res.redirect("/");
+            return;
+          }
+
+          res.json({
+            user: {
+              id: user.claims.sub,
+              email: user.claims.email,
+            },
+          });
+        });
+      },
+    )(req, res, next);
+  });
+
+  router.get("/login", (_req, res) => {
+    res.type("html").send(`<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Local login</title>
+    <style>
+      body { font-family: system-ui, sans-serif; max-width: 420px; margin: 3rem auto; line-height: 1.5; }
+      label { display: block; margin-bottom: 1rem; }
+      input { width: 100%; padding: 0.5rem; font-size: 1rem; }
+      button { padding: 0.5rem 1rem; font-size: 1rem; }
+      p { font-size: 0.9rem; color: #444; }
+    </style>
+  </head>
+  <body>
+    <h1>Local auth sign in</h1>
+    <p>Use the credentials from <code>TEST_USER_EMAIL</code> / <code>TEST_USER_PASSWORD</code>.</p>
+    <form method="post" action="">
+      <label>
+        Email
+        <input type="email" name="email" value="${defaultEmail}" autocomplete="email" required />
+      </label>
+      <label>
+        Password
+        <input type="password" name="password" value="${config.NODE_ENV !== "production" ? defaultPassword : ""}" autocomplete="current-password" required />
+      </label>
+      <button type="submit">Sign in</button>
+    </form>
+  </body>
+</html>`);
+  });
+
+  router.post("/logout", (req, res, next) => {
+    req.logout((err) => {
+      if (err) {
+        next(err);
+        return;
+      }
+
+      const wantsHtml = req.accepts(["html", "json"]) === "html";
+
+      if (wantsHtml) {
+        res.redirect("/");
+        return;
+      }
+
+      res.status(204).end();
+    });
+  });
+
+  router.get("/logout", (req, res, next) => {
+    req.logout((err) => {
+      if (err) {
+        next(err);
+        return;
+      }
+
+      res.redirect("/");
+    });
+  });
+
+  router.get("/me", async (req, res) => {
+    if (!req.isAuthenticated()) {
+      res.status(401).json({ message: "Unauthorized" });
+      return;
+    }
+
+    const claims = (req.user as LocalAuthUser)?.claims;
+    const storedUser = claims ? await storage.getUser(claims.sub) : undefined;
+
+    res.json(
+      storedUser ?? {
+        id: claims?.sub,
+        email: claims?.email ?? null,
+      },
+    );
+  });
+
+  if (config.NODE_ENV === "test" && config.TEST_SEED_TOKEN) {
+    router.post("/__test__/seed-and-login", async (req, res, next) => {
+      const { token } = req.body ?? {};
+      if (token !== config.TEST_SEED_TOKEN) {
+        res.status(401).json({ message: "Invalid seed token" });
+        return;
+      }
+
+      try {
+        await storage.upsertUser({
+          id: localUserId,
+          email: defaultEmail,
+          firstName: localUser.claims.first_name,
+          lastName: localUser.claims.last_name,
+        });
+      } catch (error) {
+        next(error);
+        return;
+      }
+
+      req.login({ ...localUser }, (err) => {
+        if (err) {
+          next(err);
+          return;
+        }
+
+        res.json({
+          user: {
+            id: localUser.claims.sub,
+            email: localUser.claims.email,
+          },
+        });
+      });
+    });
+  }
+
+  app.use(router);
+  app.use("/api", router);
+}
+
+export async function setupAuth(app: Express, config: AppConfig): Promise<void> {
+  currentMode = config.AUTH_MODE;
+  currentConfig = config;
+
+  app.set("trust proxy", 1);
+  app.use(getSession(config));
+  app.use(passport.initialize());
+  app.use(passport.session());
+
+  passport.serializeUser((user: Express.User, cb) => cb(null, user));
+  passport.deserializeUser((user: Express.User, cb) => cb(null, user));
+
+  if (config.AUTH_MODE === "oidc") {
+    await setupOidc(app, config);
+  } else {
+    setupLocal(app, config);
+  }
+}
+
 export const isAuthenticated: RequestHandler = async (req, res, next) => {
+  const config = requireConfig();
+
+  if (!req.isAuthenticated()) {
+    res.status(401).json({ message: "Unauthorized" });
+    return;
+  }
+
+  if (currentMode === "local") {
+    next();
+    return;
+  }
+
   const user = req.user as any;
 
-  if (!req.isAuthenticated() || !user.expires_at) {
-    return res.status(401).json({ message: "Unauthorized" });
+  if (!user?.expires_at) {
+    res.status(401).json({ message: "Unauthorized" });
+    return;
   }
 
   const now = Math.floor(Date.now() / 1000);
   if (now <= user.expires_at) {
-    return next();
+    next();
+    return;
   }
 
   const refreshToken = user.refresh_token;
@@ -146,12 +413,14 @@ export const isAuthenticated: RequestHandler = async (req, res, next) => {
   }
 
   try {
-    const config = await getOidcConfig();
-    const tokenResponse = await client.refreshTokenGrant(config, refreshToken);
+    const oidcConfig = await getOidcDiscovery(
+      config.OIDC_ISSUER!,
+      config.OIDC_CLIENT_ID!,
+    );
+    const tokenResponse = await client.refreshTokenGrant(oidcConfig, refreshToken);
     updateUserSession(user, tokenResponse);
-    return next();
+    next();
   } catch (error) {
     res.status(401).json({ message: "Unauthorized" });
-    return;
   }
 };

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1,13 +1,14 @@
 import type { Express } from "express";
 import { createServer, type Server } from "http";
+import type { AppConfig } from "./config";
 import { storage } from "./storage";
 import { registerOptimizeRoutes } from "./routes/api/optimize";
 import { registerContentRoutes } from "./routes/api/content";
 import { setupAuth, isAuthenticated } from "./replitAuth";
 
-export async function registerRoutes(app: Express): Promise<Server> {
+export async function registerRoutes(app: Express, config: AppConfig): Promise<Server> {
   // Setup authentication middleware
-  await setupAuth(app);
+  await setupAuth(app, config);
 
   // Auth API routes
   app.get('/api/auth/user', isAuthenticated, async (req: any, res) => {

--- a/server/services/schema-generator.ts
+++ b/server/services/schema-generator.ts
@@ -1,3 +1,5 @@
+import config from "../config";
+
 /**
  * Server-side Schema.org markup generator for content optimization
  */
@@ -10,9 +12,10 @@ export interface SchemaMarkup {
 }
 
 export async function generateSchemaMarkup(content: string, schemaData?: any): Promise<SchemaMarkup> {
-  const baseUrl = process.env.REPLIT_DOMAINS 
-    ? `https://${process.env.REPLIT_DOMAINS.split(',')[0]}`
-    : 'https://ai-seo-optimizer.com';
+  const defaultDomain = config.REPLIT_DOMAINS.split(",")[0];
+  const baseUrl = defaultDomain
+    ? `https://${defaultDomain}`
+    : "https://ai-seo-optimizer.com";
     
   // Sanitize content to remove HTML and platform banners for clean analysis
   const cleanContent = sanitizeCanonicalContent(content);

--- a/server/vite.ts
+++ b/server/vite.ts
@@ -24,6 +24,7 @@ export async function setupVite(app: Express, server: Server) {
     middlewareMode: true,
     hmr: { server },
     allowedHosts: true as const,
+    host: "0.0.0.0",
   };
 
   const vite = await createViteServer({

--- a/vendor/dotenv/config.js
+++ b/vendor/dotenv/config.js
@@ -1,0 +1,11 @@
+import load from "./loader.js";
+
+const override = process.env.DOTENV_CONFIG_OVERRIDE === "true";
+const pathOption = process.env.DOTENV_CONFIG_PATH;
+
+export const parsed = load({
+  path: pathOption && pathOption.length > 0 ? pathOption : undefined,
+  override,
+});
+
+export default parsed;

--- a/vendor/dotenv/index.js
+++ b/vendor/dotenv/index.js
@@ -1,0 +1,10 @@
+import load from "./loader.js";
+
+export function config(options = {}) {
+  const parsed = load(options);
+  return { parsed };
+}
+
+export default {
+  config,
+};

--- a/vendor/dotenv/loader.js
+++ b/vendor/dotenv/loader.js
@@ -1,0 +1,65 @@
+import fs from "fs";
+import path from "path";
+
+function normalizeValue(raw) {
+  const trimmed = raw.trim();
+  if (
+    (trimmed.startsWith("\"") && trimmed.endsWith("\"")) ||
+    (trimmed.startsWith("'") && trimmed.endsWith("'"))
+  ) {
+    return trimmed.slice(1, -1).replace(/\\n/g, "\n");
+  }
+
+  return trimmed;
+}
+
+function parse(content) {
+  const parsed = {};
+  const lines = content.split(/\r?\n/);
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (!trimmed || trimmed.startsWith("#")) {
+      continue;
+    }
+
+    const match = trimmed.match(/^(?:export\s+)?([^=]+)=(.*)$/);
+    if (!match) {
+      continue;
+    }
+
+    const key = match[1]?.trim();
+    if (!key) {
+      continue;
+    }
+
+    const rawValue = match[2] ?? "";
+    parsed[key] = normalizeValue(rawValue);
+  }
+
+  return parsed;
+}
+
+export function load(options = {}) {
+  const override = Boolean(options.override);
+  const envPath = options.path
+    ? path.resolve(process.cwd(), options.path)
+    : path.resolve(process.cwd(), ".env");
+
+  if (!fs.existsSync(envPath)) {
+    return {};
+  }
+
+  const parsed = parse(fs.readFileSync(envPath, "utf8"));
+
+  for (const [key, value] of Object.entries(parsed)) {
+    if (override || process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+
+  return parsed;
+}
+
+export default load;

--- a/vendor/dotenv/package.json
+++ b/vendor/dotenv/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "dotenv",
+  "version": "16.4.5",
+  "type": "module",
+  "main": "index.js",
+  "exports": {
+    ".": "./index.js",
+    "./config": "./config.js"
+  }
+}


### PR DESCRIPTION
## Summary
- introduce a central config module that loads environment variables, defaults to local auth when OIDC credentials are absent, and guards required secrets
- add a pluggable auth initializer with Passport local fallback routes, a guarded test seed endpoint, and a memory-session store when Postgres is unavailable
- bundle a lightweight dotenv implementation for offline installs, update docs and samples, and ensure CI forces local auth

## Testing
- `SESSION_SECRET=test AUTH_MODE=local npm run check`
- `SESSION_SECRET=test AUTH_MODE=local npm run build`

## How to run locally
1. `cp .env.sample .env`
2. Set at least `SESSION_SECRET` (optional: override `TEST_USER_EMAIL` / `TEST_USER_PASSWORD`)
3. `npm install`
4. `SESSION_SECRET=dev AUTH_MODE=local npm run dev`

## How to switch to OIDC
1. Provide `SESSION_SECRET`
2. Set `AUTH_MODE=oidc`
3. Export `OIDC_ISSUER`, `OIDC_CLIENT_ID`, `OIDC_CLIENT_SECRET`, and `OIDC_REDIRECT_URI`
4. Restart the server

## Reviewer Checklist
- [ ] Local mode runs with no OIDC envs
- [ ] OIDC mode unchanged when envs provided
- [ ] CI uses AUTH_MODE=local
- [ ] README and .env.sample updated

------
https://chatgpt.com/codex/tasks/task_e_68cc5193ac348329b6c087835b51b512