### PR TITLE
chore: default session secret for development

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -19,12 +19,16 @@ export interface AppConfig {
 
 const NODE_ENV = process.env.NODE_ENV ?? "development";
 const PORT = Number.parseInt(process.env.PORT ?? "5000", 10);
-const SESSION_SECRET = process.env.SESSION_SECRET;
+let SESSION_SECRET = process.env.SESSION_SECRET;
 
 if (!SESSION_SECRET) {
-  throw new Error(
-    "SESSION_SECRET env var is required. Set it in your .env file (see .env.sample).",
-  );
+  if (NODE_ENV !== "production") {
+    SESSION_SECRET = "development-session-secret";
+  } else {
+    throw new Error(
+      "SESSION_SECRET env var is required. Set it in your .env file (see .env.sample).",
+    );
+  }
 }
 
 const OIDC_ISSUER =


### PR DESCRIPTION
## Summary
- provide a default session secret when running outside production
- preserve production requirement for an explicit SESSION_SECRET

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_e_68cc7a7417708329b2daabc7030e74f6